### PR TITLE
Fix tensordock crash when price is 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,103 @@
-# GpuScanner
-Scans different platforms and finds cheapest GPUs.
+# [GpuScanner](https://gpufindr.com)
 
-Searches through given APIs and compiles important data into **ONE** easy-to-read site.
+A comprehensive GPU monitoring and blog automation system that tracks GPU availability and pricing across multiple cloud providers while generating automated blog content.
 
-TODO: Put hot gpus in the front page - easy to click.
-TODO: Blog every day then week
-TODO: Logo
-TODO: SEO
+https://gpufindr.com
+
+## Overview
+
+GpuScanner is a multi-component Go application that:
+- Scans and monitors GPU resources across cloud providers (AWS Lambda, RunPod, TensorDock, Vast.ai)
+- Provides a web API and frontend for GPU search and monitoring
+- Automatically generates and publishes blog content about GPU market trends
+- Integrates with MCP (Model Context Protocol) for AI-powered interactions
+
+## Architecture
+
+The project is organized into several key components:
+
+### Core Applications
+
+- **`cmd/api/`** - Web API server with frontend interface
+- **`cmd/blog/`** - Blog content generation and management system
+- **`cmd/scan/`** - GPU scanning service across multiple providers
+
+### Key Features
+
+- **Multi-Provider GPU Scanning**: Monitors GPU availability across Lambda, RunPod, TensorDock, and Vast.ai
+- **REST API**: Provides endpoints for GPU data retrieval and search
+- **Web Frontend**: HTML interface for searching and viewing GPU information
+- **Automated Blogging**: Daily blog post generation using AI
+- **MCP Integration**: Model Context Protocol support for AI interactions
+
+## Components
+
+### GPU Scanning (`cmd/scan/`)
+- `lambdaGetter.go` - AWS Lambda GPU monitoring
+- `runpodGetter.go` - RunPod GPU tracking
+- `tensordockGetter.go` - TensorDock integration
+- `vastGetter.go` - Vast.ai monitoring
+- `scan.go` - Main scanning orchestrator
+
+### API Server (`cmd/api/`)
+- `main.go` - HTTP server and routing
+- `gpu.go` - GPU-related API endpoints
+- `blog.go` - Blog management API
+- `mcp.go` - MCP protocol implementation
+- `static.go` - Static file serving
+- `frontend/` - HTML templates and UI
+
+### Blog System (`cmd/blog/`)
+- `main.go` - Blog generation entry point
+- `write.go` - Content creation and publishing
+- `upload.go` - Media and asset management
+- `types.go` - Data structures
+
+## Installation
+
+1. Clone the repository:
+```bash
+git clone https://github.com/ShayManor/GpuScanner.git
+cd GpuScanner
+```
+2. Install dependencies:
+```bash
+go mod tidy
+```
+3. Set up environment variables:
+```bash
+export SUPABASE_URL="example"
+export SUPABASE_SERVICE_KEY="example"
+export OPENAI_API_KEY="example"
+... GPU provider keys
+```
+
+## Usage
+
+### Running API
+```bash
+go run ./cmd/api
+```
+
+### Manual GPU scan
+```bash
+go run ./cmd/scan
+```
+
+### Generate Article for Blog
+```bash
+go run ./cmd/blog
+```
+
+## Automation
+
+The project includes GitHub Actions workflow (.github/workflows/blog.yaml) that:
+- Runs daily at midnight
+- Automatically generates articles
+- Publishes to Supabase
+
+## API Documentation
+
+- OpenAPI specification: `cmd/api/openapi.yaml`
+- Swagger documentation: `docs/swagger.json`
+

--- a/cmd/scan/tensordockGetter.go
+++ b/cmd/scan/tensordockGetter.go
@@ -124,6 +124,9 @@ func tensordockGetter() ([]GPU, error) {
 			}
 			totalFlops, memBWGBs, name := gpuSpecs(g.V0Name)
 			totalFlops = totalFlops / 1e12
+			if g.PricePerHr == 0 {
+				continue
+			}
 			newGpu := GPU{
 				_Id:         hn.ID,
 				Location:    loc,
@@ -154,7 +157,7 @@ func tensordockGetter() ([]GPU, error) {
 				// To keep semantics consistent with Vast, we set totalCostPH to GPU price here.
 				TotalCostPH:      g.PricePerHr,
 				GpuCostPH:        g.PricePerHr,
-				DiskCostPH:       g.PricePerHr, // per-GB rate exists, but we avoid mixing units here
+				DiskCostPH:       0, // per-GB rate exists, but we avoid mixing units here
 				UploadCostPH:     0,
 				DownloadCostPH:   0,
 				FlopsPerDollarPH: totalFlops / g.PricePerHr,
@@ -166,6 +169,9 @@ func tensordockGetter() ([]GPU, error) {
 			out = append(out, newGpu)
 
 		}
+	}
+	for gpu := range out {
+		fmt.Println(out[gpu].toString())
 	}
 
 	fmt.Printf("Found %d TensorDock GPUs\n", len(out))

--- a/cmd/scan/vastGetter.go
+++ b/cmd/scan/vastGetter.go
@@ -53,7 +53,6 @@ type offer struct {
 
 func fetchVastOffers(limit int) ([]offer, error) {
 	body := fmt.Sprintf(`{"q":{"limit":%d,"rentable":"true"}}`, limit)
-	fmt.Println(string(body))
 	req, _ := http.NewRequest("PUT", "https://console.vast.ai/api/v0/search/asks/", strings.NewReader(body))
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
Tensordock crashed from API and this broke scan because a tensordock gpu price is 0 and inf was returned (divide by 0 error). Fixed this.